### PR TITLE
README: Add semver info for peer dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,12 +87,17 @@ npm install -S [ejs|jade|swig|handlebars|emblem|dust-linkedin]
     ```
 
 2. Install the template engine you intend to use:
-    - `ejs`
-    - `jade`
-    - `swig`
-    - `handlebars`
-    - `emblem `
-    - `dust-linkedin`
+    - `ejs@^1.0.0`
+    - `jade@^1.3.1`
+    - `swig@^1.3.2`
+    - `handlebars@^1.3.0`
+    - `emblem@~0.3.16`
+    - `dust-linkedin@^2.4.0`
+
+    - `less@^1.7.0`
+    - `stylus@^^0.45.1`
+    - `styl@^0.2.7`
+    - `node-sass@^0.9.3`
 
     ```bash
     npm install -S <engine>


### PR DESCRIPTION
I discovered that this app is not compatible with less@^2, so one must run `npm i -S less@^1` rather than just `npm i -S less`.  This patch adds the semver ranges to the README as a hint to devs that they must specify a compatible version of the template engine peer dependency.
